### PR TITLE
Added equality check to Clock exercise

### DIFF
--- a/clock/ClockTest.cs
+++ b/clock/ClockTest.cs
@@ -89,4 +89,13 @@ public class ClockTest
         var clock = new Clock(1, 60);
         Assert.That(clock.ToString(), Is.EqualTo("02:00"));
     }
+
+    [Ignore]
+    [Test]
+    public void Clocks_with_same_time_are_equal()
+    {
+        var clock1 = new Clock(14, 30);
+        var clock2 = new Clock(14, 30);
+        Assert.That(clock1, Is.EqualTo(clock2));
+    }
 }


### PR DESCRIPTION
The readme file of the Clock exercise states that clocks with the same time should be equal to each other. This PR adds a check to see if that is the case.