### PR TITLE
Switch to container-based Travis CI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: bash
 script:
 - bin/fetch-configlet
 - bin/configlet .
+sudo: false


### PR DESCRIPTION
This gets us off the legacy build system, which means
that the builds will start more quickly and also likely
run more quickly (and with more consistent build times).

See https://docs.travis-ci.com/user/migrating-from-legacy.