### PR TITLE
largest-series-product corner cases

### DIFF
--- a/largest-series-product/LargestSeriesProductTest.cs
+++ b/largest-series-product/LargestSeriesProductTest.cs
@@ -72,6 +72,14 @@ public class LargestSeriesProductTest
     }
 
     [Ignore]
+    [TestCase("0000", 2, Result = 0)]
+    [TestCase("99099", 3, Result = 0)]
+    public int Largest_product_works_if_all_spans_contain_zero(string digits, int seriesLength)
+    {
+        return new LargestSeriesProduct(digits).GetLargestProduct(seriesLength);
+    }
+
+    [Ignore]
     [TestCase("", Result = 1)]
     [TestCase("123", Result = 1)]
     public int Largest_product_for_empty_span_is_1(string digits)

--- a/largest-series-product/LargestSeriesProductTest.cs
+++ b/largest-series-product/LargestSeriesProductTest.cs
@@ -72,9 +72,17 @@ public class LargestSeriesProductTest
     }
 
     [Ignore]
-    [Test]
-    public void Largest_product_for_empty_input_is_1()
+    [TestCase("", Result = 1)]
+    [TestCase("123", Result = 1)]
+    public int Largest_product_for_empty_span_is_1(string digits)
     {
-        Assert.That(new LargestSeriesProduct("").GetLargestProduct(0), Is.EqualTo(1));
+        return new LargestSeriesProduct(digits).GetLargestProduct(0);
+    }
+
+    [Ignore]
+    [Test]
+    public void Cannot_slice_empty_string_with_nonzero_span(string digits)
+    {
+        Assert.Throws<ArgumentException>(() => new LargestSeriesProduct("").GetSlices(1));
     }
 }


### PR DESCRIPTION
As part of the work to have consistency between tracks as in https://github.com/exercism/todo/issues/104 and https://github.com/exercism/todo/issues/13. Comments are in individual commit messages.