### PR TITLE
Add Fake build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 tmp
 bin/configlet
 bin/configlet.exe
+.fake/
+.vs/
+tools/
+build/
+TestResult.xml

--- a/build.fsx
+++ b/build.fsx
@@ -1,0 +1,58 @@
+// Include Fake library
+#r "tools/FAKE/tools/FakeLib.dll"
+
+open Fake
+open Fake.CscHelper
+open Fake.Testing.NUnit3
+
+// Properties
+let buildDir = getBuildParamOrDefault "buildDir" "./build/"
+let sourceDir = "./exercises/"
+let testDll = buildDir @@ "Tests.dll"
+let nunitFrameworkDll = "tools/NUnit/lib/net45/nunit.framework.dll"
+
+let sourceFiles() = !! (buildDir @@ "./**/*.cs") |> List.ofSeq
+  
+// Targets
+Target "Clean" (fun _ ->
+    CleanDir buildDir
+)
+
+Target "CopySource" (fun _ ->
+    CopyDir buildDir sourceDir allFiles
+)
+
+Target "ModifySource" (fun _ ->
+    sourceFiles()
+    |> ReplaceInFiles [("[Ignore(\"Remove to run test\")]", ""); ("; Ignore", ""); (", Ignore = \"Remove to run test case\"", "")]
+)
+
+Target "Build" (fun _ ->
+  sourceFiles()
+  |> List.ofSeq
+  |> Csc (fun p ->
+           { p with Output = testDll
+                    References = [nunitFrameworkDll]
+                    Target = Library })
+)
+
+Target "Test" (fun _ ->
+    Copy buildDir [nunitFrameworkDll]
+    
+    [testDll]
+    |> NUnit3 (fun p -> 
+        { p with
+            ShadowCopy = false })
+)
+
+Target "Default" (fun _ -> ())
+
+// Dependencies
+"Clean"
+    ==> "CopySource"
+    ==> "ModifySource"    
+    ==> "Build"    
+    ==> "Test"
+    ==> "Default"
+  
+RunTargetOrDefault "Default"

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,36 @@
+$toolsDirectory = Join-Path $PSScriptRoot "tools"
+$nugetDirectory = Join-Path $toolsDirectory "nuget"
+$nugetExe = Join-Path $nugetDirectory "nuget.exe"
+$fakeExe = Join-Path $toolsDirectory "fake/tools/fake.exe"
+$nunitFrameworkDll = Join-Path $toolsDirectory "nunit/lib/net45/nunit.framework.dll"
+$nunitConsoleExe = Join-Path $toolsDirectory "nunit.console/tools/nunit3-console.exe"
+
+If (!(Test-Path $nugetExe)) {   
+    # Ensure the directory exists (which is required by DownloadFile)
+    New-Item $nugetDirectory -Type Directory | Out-Null
+    
+    $nugetUrl = "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe"    
+	(New-Object System.Net.WebClient).DownloadFile($nugetUrl, $nugetExe)
+}
+
+If (!(Test-Path $nugetExe)) {
+	Throw "Could not find nuget.exe"
+}
+
+& $nugetExe install FAKE -Version 4.17.1 -ExcludeVersion -OutputDirectory $toolsDirectory
+If (!(Test-Path $fakeExe)) {
+	Throw "Could not find fake.exe"
+}
+
+& $nugetExe install NUnit -Version 3.0.1 -ExcludeVersion -OutputDirectory $toolsDirectory
+If (!(Test-Path $nunitFrameworkDll)) {
+	Throw "Could not find nunit.framework.dll"
+}
+
+& $nugetExe install NUnit.Console -Version 3.0.1 -ExcludeVersion -OutputDirectory $toolsDirectory
+If (!(Test-Path $nunitConsoleExe)) {
+	Throw "Could not find nunit3-console.exe"
+}
+
+# Use FAKE to execute the build script
+& $fakeExe $args

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+currentDirectory="$( cd "$( dirname "$0" )" && pwd )"
+toolsDirectory=$currentDirectory/tools
+nugetDirectory=$toolsDirectory/nuget
+nugetExe=$nugetDirectory/nuget.exe
+fakeExe=$toolsDirectory/FAKE/tools/FAKE.exe
+nunitFrameworkDll=$toolsDirectory/NUnit/lib/nunit.framework.dll
+nunitConsoleExe=$toolsDirectory/NUnit.Console/tools/nunit3-console.exe
+
+if test ! -d $nugetDirectory; then
+    mkdir -p $nugetDirectory
+fi
+
+if test ! -f $nugetExe; then
+    nugetUrl="https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe"
+    wget -O $nugetExe $nugetUrl 2> /dev/null || curl -o $nugetExe --location $nugetUrl /dev/null
+    
+    if test ! -f $nugetExe; then
+        echo "Could not find nuget.exe"
+        exit 1
+    fi
+    
+    chmod 755 $nugetExe
+fi
+
+mono $nugetExe install FAKE -Version 4.17.1 -ExcludeVersion -OutputDirectory $toolsDirectory
+if test ! -f $fakeExe; then
+	echo "Could not find fake.exe"
+    exit 1
+fi
+
+mono $nugetExe install NUnit -Version 2.6.4 -ExcludeVersion -OutputDirectory $toolsDirectory
+if test ! -f $nunitFrameworkDll; then
+	echo "Could not find nunit.framework.dll"
+    exit 1
+fi
+
+mono $nugetExe install NUnit.Console -Version 3.0.1 -ExcludeVersion -OutputDirectory $toolsDirectory
+if test ! -f $nunitConsoleExe; then
+	echo "Could not find nunit3-console.exe"
+    exit 1
+fi
+
+# Use FAKE to execute the build script
+mono $fakeExe build.fsx $@

--- a/exercises/crypto-square/CryptoSquareTest.cs
+++ b/exercises/crypto-square/CryptoSquareTest.cs
@@ -103,7 +103,7 @@ public class CryptoSquareTest
     public void Normalized_ciphertext_not_exactly_divisible_by_5_spills_into_a_smaller_segment()
     {
         var crypto = new Crypto("Madness, and then illumination.");
-        Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("msemo aanin dninn dlaet ltshu i"));
+        Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("msemo aanin dnin ndla etlt shui"));
     }
 
     [Ignore("Remove to run test")]
@@ -111,7 +111,7 @@ public class CryptoSquareTest
     public void Normalized_ciphertext_is_split_into_segements_of_correct_size()
     {
         var crypto = new Crypto("If man was meant to stay on the ground god would have given us roots");
-        Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghns seoau"));
+        Assert.That(crypto.NormalizeCiphertext(), Is.EqualTo("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau"));
     }
 
     [Ignore("Remove to run test")]

--- a/exercises/largest-series-product/LargestSeriesProductTest.cs
+++ b/exercises/largest-series-product/LargestSeriesProductTest.cs
@@ -89,7 +89,7 @@ public class LargestSeriesProductTest
 
     [Ignore("Remove to run test")]
     [Test]
-    public void Cannot_slice_empty_string_with_nonzero_span(string digits)
+    public void Cannot_slice_empty_string_with_nonzero_span()
     {
         Assert.Throws<ArgumentException>(() => new LargestSeriesProduct("").GetSlices(1));
     }


### PR DESCRIPTION
This PR adds a Fake build script that allows all tests to run against the example implementations.

In the process, I immediately benefitted from having these automatic tests: the `LargestSeriesProductTest` class contained an incorrect test (parameterized test which was not defined as such).

Furthermore, the tests for the crypto-square exercise failed. This turned out to be both an implementation issue as well as test for the wrong expected values. For the correct expected values, I check several other language tracks, including the Haskell and Clojure tracks, which both had the same expected value that our test did not have.