### PR TITLE
Use FAKE build in Travis and AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
----
-language: bash
+language: csharp
+
 script:
-- bin/fetch-configlet
-- bin/configlet .
-sudo: false
+  - bin/fetch-configlet
+  - bin/configlet .
+  - build.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,2 @@
+build_script:
+- ps: .\build.ps1


### PR DESCRIPTION
This PR modifies the Travis build to use the new `build.sh` file, which runs the FAKE build.

It also adds the `appveyor.yml` file. I'm unable to actually create the AppVeyor project, as I'm not a contributor to this repository. I did test it on my fork's AppVeyor project and it worked. Perhaps someone could create the AppVeyor project?