### PR TITLE
Add matrix exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -56,7 +56,8 @@
     "palindrome-products",
     "binary-search-tree",
     "robot-simulator",
-    "simple-linked-list"
+    "simple-linked-list",
+    "matrix"
   ],
   "deprecated": [
 

--- a/exercises/matrix/Example.cs
+++ b/exercises/matrix/Example.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+
+public class Matrix
+{
+    private readonly int[][] _rows;
+    private readonly int[][] _cols;
+
+    public Matrix(string input)
+    {
+        _rows = ParseRows(input);
+        _cols = ParseCols(_rows);
+    }
+
+    public int Rows => _rows.Length;
+    public int Cols => _cols.Length;
+
+    public int[] Row(int row) => _rows[row];
+    public int[] Col(int col) => _cols[col];
+
+    private static int[][] ParseRows(string input)
+    {
+        return input.Split('\n')
+            .Select(ParseRow)
+            .ToArray();
+    }
+
+    private static int[] ParseRow(string row)
+    {
+        return row.Split(' ')
+            .Select(int.Parse)
+            .ToArray();
+    }
+
+    private static int[][] ParseCols(int[][] rows)
+    {
+        return Enumerable.Range(0, rows[0].Length)
+            .Select(y => ParseCol(rows, y))
+            .ToArray();
+    }
+
+    private static int[] ParseCol(int[][] rows, int y)
+    {
+        return Enumerable.Range(0, rows.Length)
+            .Select(x => rows[x][y])
+            .ToArray();
+    }
+}

--- a/exercises/matrix/MatrixTest.cs
+++ b/exercises/matrix/MatrixTest.cs
@@ -1,0 +1,63 @@
+﻿using NUnit.Framework;
+
+public class MatrixTest
+{
+    [TestCase("1", ExpectedResult = new[] { 1 })]
+    [TestCase("4 7", ExpectedResult = new[] { 4, 7 }, Ignore = "Remove to run test case")]
+    [TestCase("1 2\n10 20", ExpectedResult = new[] { 1, 2 }, Ignore = "Remove to run test case")]
+    [TestCase("9 7 6\n8 6 5\n5 3 2", ExpectedResult = new[] { 9, 7, 6 }, Ignore = "Remove to run test case")]
+    public int[] Extract_first_row(string input)
+    {
+        var matrix = new Matrix(input);
+        return matrix.Row(0);
+    }
+
+    [TestCase("5", ExpectedResult = new[] { 5 }, Ignore = "Remove to run test case")]
+    [TestCase("9 7", ExpectedResult = new[] { 9, 7 }, Ignore = "Remove to run test case")]
+    [TestCase("9 8 7\n19 18 17", ExpectedResult = new[] { 19, 18, 17 }, Ignore = "Remove to run test case")]
+    [TestCase("1 4 9\n16 25 36\n5 6 7", ExpectedResult = new[] { 5, 6, 7 }, Ignore = "Remove to run test case")]
+    public int[] Extract_last_row(string input)
+    {
+        var matrix = new Matrix(input);
+        return matrix.Row(matrix.Rows - 1);
+    }
+
+    [TestCase("55 44", ExpectedResult = new[] { 55 }, Ignore = "Remove to run test case")]
+    [TestCase("89 1903\n18 3", ExpectedResult = new[] { 89, 18 }, Ignore = "Remove to run test case")]
+    [TestCase("1 2 3\n4 5 6\n7 8 9\n8 7 6", ExpectedResult = new[] { 1, 4, 7, 8 }, Ignore = "Remove to run test case")]
+    public int[] Extract_first_column(string input)
+    {
+        var matrix = new Matrix(input);
+        return matrix.Col(0);
+    }
+
+    [TestCase("28", ExpectedResult = new[] { 28 }, Ignore = "Remove to run test case")]
+    [TestCase("13\n16\n19", ExpectedResult = new[] { 13, 16, 19 }, Ignore = "Remove to run test case")]
+    [TestCase("289 21903 23\n218 23 21", ExpectedResult = new[] { 23, 21 }, Ignore = "Remove to run test case")]
+    [TestCase("11 12 13\n14 15 16\n17 18 19\n18 17 16", ExpectedResult = new[] { 13, 16, 19, 16 }, Ignore = "Remove to run test case")]
+    public int[] Extract_last_column(string input)
+    {
+        var matrix = new Matrix(input);
+        return matrix.Col(matrix.Cols - 1);
+    }
+
+    [TestCase("28", ExpectedResult = 1, Ignore = "Remove to run test case")]
+    [TestCase("13\n16", ExpectedResult = 2, Ignore = "Remove to run test case")]
+    [TestCase("289 21903\n23 218\n23 21", ExpectedResult = 3, Ignore = "Remove to run test case")]
+    [TestCase("11 12 13\n14 15 16\n17 18 19\n18 17 16", ExpectedResult = 4, Ignore = "Remove to run test case")]
+    public int Number_of_rows(string input)
+    {
+        var matrix = new Matrix(input);
+        return matrix.Rows;
+    }
+
+    [TestCase("28", ExpectedResult = 1, Ignore = "Remove to run test case")]
+    [TestCase("13 2\n16 3\n19 4", ExpectedResult = 2, Ignore = "Remove to run test case")]
+    [TestCase("289 21903\n23 218\n23 21", ExpectedResult = 2, Ignore = "Remove to run test case")]
+    [TestCase("11 12 13\n14 15 16\n17 18 19\n18 17 16", ExpectedResult = 3, Ignore = "Remove to run test case")]
+    public int Number_of_columns(string input)
+    {
+        var matrix = new Matrix(input);
+        return matrix.Cols;
+    }
+}

--- a/exercises/saddle-points/Example.cs
+++ b/exercises/saddle-points/Example.cs
@@ -2,20 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-public class Matrix
+public class SaddlePoints
 {
     private readonly int[,] values;
     private readonly int[] maxRows;
     private readonly int[] minCols;
 
-    public Matrix(int[,] values)
+    public SaddlePoints(int[,] values)
     {
         this.values = values;
         this.maxRows = Rows().Select(r => r.Max()).ToArray();
         this.minCols = Columns().Select(r => r.Min()).ToArray();
     }
 
-    public IEnumerable<Tuple<int, int>> SaddlePoints()
+    public IEnumerable<Tuple<int, int>> Calculate()
     {
         return Coordinates().Where(IsSaddlePoint);
     }

--- a/exercises/saddle-points/SaddlePointTests.cs
+++ b/exercises/saddle-points/SaddlePointTests.cs
@@ -12,7 +12,7 @@ public class SaddlePointTests
             { 5, 3, 2 }, 
             { 6, 6, 7 }
         };
-        var actual = new Matrix(values).SaddlePoints();
+        var actual = new SaddlePoints(values).Calculate();
         Assert.That(actual, Is.EqualTo(new [] { Tuple.Create(1, 0)}));
     }
 
@@ -25,7 +25,7 @@ public class SaddlePointTests
             { 2, 1 }, 
             { 1, 2 }
         };
-        var actual = new Matrix(values).SaddlePoints();
+        var actual = new SaddlePoints(values).Calculate();
         Assert.That(actual, Is.Empty);
     }
 
@@ -38,7 +38,7 @@ public class SaddlePointTests
             { 1, 2 }, 
             { 3, 4 }
         };
-        var actual = new Matrix(values).SaddlePoints();
+        var actual = new SaddlePoints(values).Calculate();
         Assert.That(actual, Is.EqualTo(new[] { Tuple.Create(0, 1) }));
     }
 
@@ -52,7 +52,7 @@ public class SaddlePointTests
             { 38, 10,  8, 77, 320 }, 
             {  3,  4,  8,  6,   7 }
         };
-        var actual = new Matrix(values).SaddlePoints();
+        var actual = new SaddlePoints(values).Calculate();
         Assert.That(actual, Is.EqualTo(new[] { Tuple.Create(2, 2) }));
     }
 
@@ -66,7 +66,7 @@ public class SaddlePointTests
             { 3, 5, 5 },
             { 1, 5, 4 }
         };
-        var actual = new Matrix(values).SaddlePoints();
+        var actual = new SaddlePoints(values).Calculate();
         Assert.That(actual, Is.EqualTo(new[] { Tuple.Create(0, 1), Tuple.Create(1, 1), Tuple.Create(2, 1) }));
     }
 }


### PR DESCRIPTION
This PR adds the `matrix` exercise. In order to prevent conflicting type names, the `Matrix` class in the `saddle-points` exercise has been renamed to `SaddlePoints`.