### PR TITLE
Remove unnecessary Reverse() method in simple-linked-list

### DIFF
--- a/exercises/simple-linked-list/Example.cs
+++ b/exercises/simple-linked-list/Example.cs
@@ -46,11 +46,6 @@ public class SimpleLinkedList<T> : IEnumerable<T>
         return this;
     }
 
-    public SimpleLinkedList<T> Reverse()
-    {
-        return new SimpleLinkedList<T>(this.AsEnumerable().Reverse());
-    }
-
     public IEnumerator<T> GetEnumerator()
     {
         yield return Value;


### PR DESCRIPTION
This is unnecessary due to already implementing `IEnumerable<T>`