### PR TITLE
largest-series-product: Do not test digits/slices

### DIFF
--- a/exercises/largest-series-product/Example.cs
+++ b/exercises/largest-series-product/Example.cs
@@ -6,7 +6,7 @@ public class LargestSeriesProduct
 {
     private readonly string digits;
 
-    public int[] Digits { get; private set; }
+    private int[] Digits;
 
     public LargestSeriesProduct(string digits)
     {
@@ -19,7 +19,7 @@ public class LargestSeriesProduct
         return values.Select(x => int.Parse(x.ToString())).ToArray();
     }
 
-    public int[][] GetSlices(int limit)
+    private int[][] GetSlices(int limit)
     {
         if (limit > digits.Length) throw new ArgumentException("Slice size is too big");
         var slices = new List<int[]>();

--- a/exercises/largest-series-product/LargestSeriesProductTest.cs
+++ b/exercises/largest-series-product/LargestSeriesProductTest.cs
@@ -41,4 +41,12 @@ public class LargestSeriesProductTest
     {
         return new LargestSeriesProduct(digits).GetLargestProduct(0);
     }
+
+    [Ignore("Remove to run test")]
+    [TestCase("123", 4)]
+    [TestCase("", 1)]
+    public void Cannot_take_largest_product_of_more_digits_than_input(string digits, int seriesLength)
+    {
+        Assert.Throws<ArgumentException>(() => new LargestSeriesProduct(digits).GetLargestProduct(seriesLength));
+    }
 }

--- a/exercises/largest-series-product/LargestSeriesProductTest.cs
+++ b/exercises/largest-series-product/LargestSeriesProductTest.cs
@@ -4,51 +4,6 @@ using NUnit.Framework;
 [TestFixture]
 public class LargestSeriesProductTest
 {
-    [Test]
-    public void Splits_out_digits()
-    {
-        Assert.That(new LargestSeriesProduct("0123456789").Digits, Is.EqualTo(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
-    }
-
-    [Ignore("Remove to run test")]
-    [Test]
-    public void Digits_maintain_order()
-    {
-        Assert.That(new LargestSeriesProduct("9876543210").Digits, Is.EqualTo(new[] { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }));
-    }
-
-    [Ignore("Remove to run test")]
-    [Test]
-    public void Digits_is_an_empty_array_for_empty_input()
-    {
-        Assert.That(new LargestSeriesProduct("").Digits, Is.Empty);
-    }
-
-    [Ignore("Remove to run test")]
-    [Test]
-    public void Slices_digits_by_limit_given()
-    {
-        Assert.That(new LargestSeriesProduct("01234").GetSlices(2),
-            Is.EqualTo(new[] { new[] { 0, 1 }, new[] { 1, 2 }, new[] { 2, 3 }, new[] { 3, 4 } }));
-    }
-
-    [Ignore("Remove to run test")]
-    [Test]
-    public void Slices_are_as_long_as_the_limit_given()
-    {
-        Assert.That(new LargestSeriesProduct("982347").GetSlices(3),
-            Is.EqualTo(new[] { new[] { 9, 8, 2 }, new[] { 8, 2, 3 }, new[] { 2, 3, 4 }, new[] { 3, 4, 7 } }));
-    }
-
-    [Ignore("Remove to run test")]
-    [Test]
-    public void Cannot_slice_bigger_than_input()
-    {
-        var ex = Assert.Throws<ArgumentException>(() => new LargestSeriesProduct("123").GetSlices(4));
-        Assert.That(ex.Message, Is.EqualTo("Slice size is too big"));
-    }
-
-    [Ignore("Remove to run test")]
     [TestCase("01234567890", 2, ExpectedResult = 72)]
     [TestCase("1027839564", 3, ExpectedResult = 270)]
     public int Gets_the_largest_product(string digits, int seriesLength)
@@ -85,12 +40,5 @@ public class LargestSeriesProductTest
     public int Largest_product_for_empty_span_is_1(string digits)
     {
         return new LargestSeriesProduct(digits).GetLargestProduct(0);
-    }
-
-    [Ignore("Remove to run test")]
-    [Test]
-    public void Cannot_slice_empty_string_with_nonzero_span()
-    {
-        Assert.Throws<ArgumentException>(() => new LargestSeriesProduct("").GetSlices(1));
     }
 }


### PR DESCRIPTION
The digits and slices functions are internal implementation details and
thus the test case for the largest-series-product problem should not be
concerned with testing them. The series tests could potentially be moved
to the series exercise (already implemented by this track).

Their presence may cause students to falsely think that their solution
has to use these two functions, instead of the alternative
implementation of only iterating through the digits once.

If it is desired to give hints on how to approach this problem (which
was one advantage of having the digits and slices tests), then consider
including a hints file and/or directory in the largest-series-product
directory.

This PR arises from discussion in
https://github.com/exercism/x-common/issues/192