### PR TITLE
Update help links to point to new help locations

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -21,11 +21,11 @@ This is a Visual Studio template that comes pre-configured to work on the proble
 
 1. Download the [Exercism.io Visual Studio Template](https://github.com/rprouse/Exercism.VisualStudio) from GitHub by clicking the Download Zip button on the page.
 2. Unzip the template into your exercises directory, for example `C:\src\exercises`
-2. Install the [Exercism CLI](http://help.exercism.io/installing-the-cli.html)
+2. Install the [Exercism CLI](http://exercism.io/cli)
 3. Open a command prompt to your exercise directory
 4. Add your API key to exercism `exercism configure --key=YOUR_API_KEY`
 5. Configure your source directory in exercism `exercism configure --dir=C:\src\exercises`
-6. [Fetch your first exercise](http://help.exercism.io/fetching-exercises.html) `exercism fetch csharp`
+6. [Fetch your first exercise](http://exercism.io/how-it-works/newbie) `exercism fetch csharp`
 7. Open the Exercism solution in Visual Studio
 8. Expand the Exercism.csharp project
 9. Click on **Show All Files** in Solution Explorer (See below)


### PR DESCRIPTION
Fixes #67. The only links to the old help site were to setting up the CLI so changed them to point to the new versions (or something that feels similar). If these look OK, please merge.