### PR TITLE
Improved linking to NUnit Test Adapter for Visual Studio for New-Project path

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -69,6 +69,10 @@ The manager is the easiest way to get started.
 
 The project should now be able to compile.
 
+The next piece required is the NUnit Test Adapter for Visual Studio.  The major version of the Test Adapter must match the major version of the NUnit Framework that you installed above, or the Visual Studio Test Explorer window will not detect your unit tests.
+- [Adapter Version 3 for NUnit 3.x](https://visualstudiogallery.msdn.microsoft.com/0da0f6bd-9bb6-4ae3-87a8-537788622f2d)
+- [Adapter Version 2 for NUnit 2.x](https://visualstudiogallery.msdn.microsoft.com/6ab922d0-21c0-4f06-ab5f-4ecd1fe7175d)
+
 To start implementing the exercise, in Visual Studio, right click on where you want the file to go to and go to `Add` -> `Class`. Name it what you'd like.
 
 ![New Item](http://x.exercism.io/v3/tracks/csharp/docs/img/addNewClass.png)


### PR DESCRIPTION
Addresses issue https://github.com/exercism/xcsharp/issues/84

Issue Details:

The installation path for "Exercism.io Visual Studio Template" includes a template with NUnit 2.x framework, and correctly links to the NUnit 2.0 Test Adapter plugin for Visual Studio.

The alternative path "Create a New Visual Studio Project" suggests using nuget to install NUnit, which likely leads to an installation of the latest framework, version 3.x.  Then there is no link/instruction to install the NUnit Test Adapter in this path, but I believe it is required because when I tested without, VS did not discover my tests.  If the reader follows the link to Adapter 2.0 from the "Template" install path, they will get a mixed install: 3.x of framework, with 2.0 of Adapter.  This results in still being unable to locate the tests in the Visual Studio Test Explorer window.

Fix:

This pull request adds a section to the "Create a New Visual Studio Project" path which explicitly links to multiple versions of the Adapter and warns that the major version number must agree between adapter and framework.  This assertion is based on the description in the Adapter download page, which says, "NUnit 3 adapter for running tests in Visual Studio. Works with NUnit 3.x, use the NUnit 2 adapter for 2.x"

I feel a more complete fix would be to update the template to use v3.x of NUnit.
