### PR TITLE
Add topics

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,336 +66,460 @@
       "slug": "leap",
       "difficulty": 1,
       "topics": [
+        "Integers"
       ]
     },
     {
       "slug": "bob",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Control-flow (if-else statements)"
       ]
     },
     {
       "slug": "etl",
       "difficulty": 1,
       "topics": [
+        "Dictionaries",
+        "Lists",
+        "Transforming"
       ]
     },
     {
       "slug": "anagram",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Filtering"
       ]
     },
     {
       "slug": "hamming",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Filtering"
       ]
     },
     {
       "slug": "word-count",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Dictionaries",
+        "Transforming"
       ]
     },
     {
       "slug": "grade-school",
       "difficulty": 1,
       "topics": [
+        "Lists",
+        "Sorting"
       ]
     },
     {
       "slug": "nucleotide-count",
       "difficulty": 1,
       "topics": [
+        "Dictionaries",
+        "Strings"
       ]
     },
     {
       "slug": "phone-number",
       "difficulty": 1,
       "topics": [
+        "Parsing",
+        "Transforming"
       ]
     },
     {
       "slug": "robot-name",
       "difficulty": 1,
       "topics": [
+        "Randomness",
+        "Strings",
+        "Classes"
       ]
     },
     {
       "slug": "sum-of-multiples",
       "difficulty": 1,
       "topics": [
+        "Arrays",
+        "Transforming"
       ]
     },
     {
       "slug": "meetup",
       "difficulty": 1,
       "topics": [
+        "Dates"
       ]
     },
     {
       "slug": "twelve-days",
       "difficulty": 1,
       "topics": [
+        "Text formatting",
+        "Algorithms"
       ]
     },
     {
       "slug": "space-age",
       "difficulty": 1,
       "topics": [
+        "Floating-point numbers"
       ]
     },
     {
       "slug": "gigasecond",
       "difficulty": 1,
       "topics": [
+        "Dates"
       ]
     },
     {
       "slug": "triangle",
       "difficulty": 1,
       "topics": [
+        "Integers",
+        "Enumerations"
       ]
     },
     {
       "slug": "scrabble-score",
       "difficulty": 1,
       "topics": [
+        "Transforming"
       ]
     },
     {
       "slug": "roman-numerals",
       "difficulty": 1,
       "topics": [
+        "Control-flow (loops)",
+        "Transforming"
       ]
     },
     {
       "slug": "binary",
       "difficulty": 1,
       "topics": [
+        "Integers",
+        "Parsing",
+        "Transforming"
       ]
     },
     {
       "slug": "prime-factors",
       "difficulty": 1,
       "topics": [
+        "Integers",
+        "Mathematics"
       ]
     },
     {
       "slug": "raindrops",
       "difficulty": 1,
       "topics": [
+        "Text formatting",
+        "Filtering"
       ]
     },
     {
       "slug": "allergies",
       "difficulty": 1,
-      "topics": [
+      "topics": [  	
+        "Bitwise operations",
+        "Filtering"
       ]
     },
     {
       "slug": "strain",
       "difficulty": 1,
       "topics": [
+        "Sequences",
+        "Filtering"
       ]
     },
     {
       "slug": "atbash-cipher",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Algorithms",
+        "Transforming"
       ]
     },
     {
       "slug": "accumulate",
       "difficulty": 1,
       "topics": [
+        "Extension methods",
+        "Sequences",
+        "Transforming"
       ]
     },
     {
       "slug": "crypto-square",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Algorithms",
+        "Transforming"
       ]
     },
     {
       "slug": "trinary",
       "difficulty": 1,
       "topics": [
+        "Integers",
+        "Parsing",
+        "Transforming"
       ]
     },
     {
       "slug": "rna-transcription",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Transforming"
       ]
     },
     {
       "slug": "sieve",
       "difficulty": 1,
       "topics": [
+        "Filtering",
+        "Mathematics"
       ]
     },
     {
       "slug": "simple-cipher",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Algorithms",
+        "Transforming"
       ]
     },
     {
       "slug": "octal",
       "difficulty": 1,
       "topics": [
+        "Integers",
+        "Parsing",
+        "Transforming"
       ]
     },
     {
       "slug": "luhn",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Algorithms",
+        "Transforming"
       ]
     },
     {
       "slug": "pig-latin",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Transforming"
       ]
     },
     {
       "slug": "pythagorean-triplet",
       "difficulty": 1,
       "topics": [
+        "Overloading",
+        "Integers",
+        "Mathematics"
       ]
     },
     {
       "slug": "series",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Arrays",
+        "Transforming"
       ]
     },
     {
       "slug": "difference-of-squares",
       "difficulty": 1,
       "topics": [
+        "Integers"
       ]
     },
     {
       "slug": "secret-handshake",
       "difficulty": 1,
       "topics": [
+        "Bitwise operations",
+        "Arrays"
       ]
     },
     {
       "slug": "clock",
       "difficulty": 1,
       "topics": [
+        "Time",
+        "Structural equality"
       ]
     },
     {
       "slug": "linked-list",
       "difficulty": 1,
       "topics": [
+        "Classes",
+        "Lists"
       ]
     },
     {
       "slug": "wordy",
       "difficulty": 1,
       "topics": [
+        "Parsing",
+        "Strings",
+        "Transforming"
       ]
     },
     {
       "slug": "tournament",
       "difficulty": 1,
       "topics": [
+        "Text formatting",
+        "Parsing"
       ]
     },
     {
       "slug": "acronym",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Transforming"
       ]
     },
     {
       "slug": "hexadecimal",
       "difficulty": 1,
       "topics": [
+        "Integers",
+        "Parsing",
+        "Transforming"
       ]
     },
     {
       "slug": "largest-series-product",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Integers",
+        "Transforming"
       ]
     },
     {
       "slug": "beer-song",
       "difficulty": 1,
       "topics": [
+        "Text formatting",
+        "Algorithms"
       ]
     },
     {
       "slug": "kindergarten-garden",
       "difficulty": 1,
       "topics": [
+        "Parsing",
+        "Enumerations"
       ]
     },
     {
       "slug": "pascals-triangle",
       "difficulty": 1,
       "topics": [
+        "Control-flow (loops)",
+        "Arrays",
+        "Mathematics"
       ]
     },
     {
       "slug": "saddle-points",
       "difficulty": 1,
       "topics": [
+        "Matrices",
+        "Arrays",
+        "Tuples"
       ]
     },
     {
       "slug": "nth-prime",
       "difficulty": 1,
       "topics": [
+        "Mathematics"
       ]
     },
     {
       "slug": "palindrome-products",
       "difficulty": 1,
       "topics": [
+        "Strings",
+        "Tuples",
+        "Algorithms"
       ]
     },
     {
       "slug": "binary-search-tree",
       "difficulty": 1,
       "topics": [
+        "Searching",
+        "Trees",
+        "Overloading"
       ]
     },
     {
       "slug": "robot-simulator",
       "difficulty": 1,
       "topics": [
+        "Classes",
+        "Enumerations"
       ]
     },
     {
       "slug": "simple-linked-list",
       "difficulty": 1,
       "topics": [
+        "Classes",
+        "Lists"
       ]
     },
     {
       "slug": "matrix",
       "difficulty": 1,
       "topics": [
+        "Matrices",
+        "Parsing"
       ]
     },
     {
       "slug": "queen-attack",
       "difficulty": 1,
       "topics": [
+        "Classes"
       ]
     },
     {
       "slug": "ocr-numbers",
       "difficulty": 1,
       "topics": [
+        "Parsing",
+        "Pattern recognition"
       ]
     }
   ],


### PR DESCRIPTION
As explained in #82, the new exercises format has support for specifying the topics of an exercise. This PR is an initial attempt to assign topics to the existing exercises. Hopefully, we can have a bit of a discussion on whether the suggested topics make sense or not.

More specifically, @jwood803 and @bressain, you are the other top contributors. Would you mind taking a look? Just to be clear, anyone is invited to share his/her opinion here. 