### PR TITLE
Align naming in LinkedList exercise

### DIFF
--- a/exercises/linked-list/Example.cs
+++ b/exercises/linked-list/Example.cs
@@ -1,4 +1,4 @@
-public class Deque<T>
+public class LinkedList<T>
 {
     private Element head;
 

--- a/exercises/linked-list/LinkedListTest.cs
+++ b/exercises/linked-list/LinkedListTest.cs
@@ -1,94 +1,94 @@
 using NUnit.Framework;
 
 [TestFixture]
-public class DequeTest
+public class LinkedListTest
 {
-    private Deque<int> deque;
+    private LinkedList<int> linkedList;
 
     [SetUp]
     public void Setup()
     {
-        deque = new Deque<int>();
+        linkedList = new LinkedList<int>();
     }
 
     [Test]
     public void Push_and_pop_are_first_in_last_out_order()
     {
-        deque.Push(10);
-        deque.Push(20);
-        Assert.That(deque.Pop(), Is.EqualTo(20));
-        Assert.That(deque.Pop(), Is.EqualTo(10));
+        linkedList.Push(10);
+        linkedList.Push(20);
+        Assert.That(linkedList.Pop(), Is.EqualTo(20));
+        Assert.That(linkedList.Pop(), Is.EqualTo(10));
     }
 
     [Ignore("Remove to run test")]
     [Test]
     public void Push_and_shift_are_first_in_first_out_order()
     {
-        deque.Push(10);
-        deque.Push(20);
-        Assert.That(deque.Shift(), Is.EqualTo(10));
-        Assert.That(deque.Shift(), Is.EqualTo(20));
+        linkedList.Push(10);
+        linkedList.Push(20);
+        Assert.That(linkedList.Shift(), Is.EqualTo(10));
+        Assert.That(linkedList.Shift(), Is.EqualTo(20));
     }
 
     [Ignore("Remove to run test")]
     [Test]
     public void Unshift_and_shift_are_last_in_first_out_order()
     {
-        deque.Unshift(10);
-        deque.Unshift(20);
-        Assert.That(deque.Shift(), Is.EqualTo(20));
-        Assert.That(deque.Shift(), Is.EqualTo(10));
+        linkedList.Unshift(10);
+        linkedList.Unshift(20);
+        Assert.That(linkedList.Shift(), Is.EqualTo(20));
+        Assert.That(linkedList.Shift(), Is.EqualTo(10));
     }
 
     [Ignore("Remove to run test")]
     [Test]
     public void Unshift_and_pop_are_last_in_last_out_order()
     {
-        deque.Unshift(10);
-        deque.Unshift(20);
-        Assert.That(deque.Pop(), Is.EqualTo(10));
-        Assert.That(deque.Pop(), Is.EqualTo(20));
+        linkedList.Unshift(10);
+        linkedList.Unshift(20);
+        Assert.That(linkedList.Pop(), Is.EqualTo(10));
+        Assert.That(linkedList.Pop(), Is.EqualTo(20));
     }
 
     [Ignore("Remove to run test")]
     [Test]
     public void Push_and_pop_can_handle_multiple_values()
     {
-        deque.Push(10);
-        deque.Push(20);
-        deque.Push(30);
-        Assert.That(deque.Pop(), Is.EqualTo(30));
-        Assert.That(deque.Pop(), Is.EqualTo(20));
-        Assert.That(deque.Pop(), Is.EqualTo(10));
+        linkedList.Push(10);
+        linkedList.Push(20);
+        linkedList.Push(30);
+        Assert.That(linkedList.Pop(), Is.EqualTo(30));
+        Assert.That(linkedList.Pop(), Is.EqualTo(20));
+        Assert.That(linkedList.Pop(), Is.EqualTo(10));
     }
 
     [Ignore("Remove to run test")]
     [Test]
     public void Unshift_and_shift_can_handle_multiple_values()
     {
-        deque.Unshift(10);
-        deque.Unshift(20);
-        deque.Unshift(30);
-        Assert.That(deque.Shift(), Is.EqualTo(30));
-        Assert.That(deque.Shift(), Is.EqualTo(20));
-        Assert.That(deque.Shift(), Is.EqualTo(10));
+        linkedList.Unshift(10);
+        linkedList.Unshift(20);
+        linkedList.Unshift(30);
+        Assert.That(linkedList.Shift(), Is.EqualTo(30));
+        Assert.That(linkedList.Shift(), Is.EqualTo(20));
+        Assert.That(linkedList.Shift(), Is.EqualTo(10));
     }
 
     [Ignore("Remove to run test")]
     [Test]
-    public void All_methods_of_manipulating_the_deque_can_be_used_together()
+    public void All_methods_of_manipulating_the_linkedList_can_be_used_together()
     {
-        deque.Push(10);
-        deque.Push(20);
-        Assert.That(deque.Pop(), Is.EqualTo(20));
+        linkedList.Push(10);
+        linkedList.Push(20);
+        Assert.That(linkedList.Pop(), Is.EqualTo(20));
 
-        deque.Push(30);
-        Assert.That(deque.Shift(), Is.EqualTo(10));
+        linkedList.Push(30);
+        Assert.That(linkedList.Shift(), Is.EqualTo(10));
 
-        deque.Unshift(40);
-        deque.Push(50);
-        Assert.That(deque.Shift(), Is.EqualTo(40));
-        Assert.That(deque.Pop(), Is.EqualTo(50));
-        Assert.That(deque.Shift(), Is.EqualTo(30));
+        linkedList.Unshift(40);
+        linkedList.Push(50);
+        Assert.That(linkedList.Shift(), Is.EqualTo(40));
+        Assert.That(linkedList.Pop(), Is.EqualTo(50));
+        Assert.That(linkedList.Shift(), Is.EqualTo(30));
     }
 }


### PR DESCRIPTION
Here's the corresponding PR to make the same change in F#:
https://github.com/exercism/xfsharp/pull/222