### PR TITLE
Bank account with threads

### DIFF
--- a/exercises/bank-account/BankAccountTest.cs
+++ b/exercises/bank-account/BankAccountTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 public class BankAccountTest
@@ -56,5 +58,32 @@ public class BankAccountTest
         account.Close();
 
         Assert.Throws<InvalidOperationException>(() => account.GetBalance());
+    }
+
+    [Ignore("Remove to run test")]
+    [Test]
+    public void Change_account_balance_from_multiple_threads()
+    {
+        var account = new BankAccount();
+        var tasks = new List<Task>();
+
+        var threads = 500;
+        var iterations = 100;
+
+        account.Open();
+        for (int i = 0; i < threads; i++)
+        {
+            tasks.Add(Task.Factory.StartNew(() =>
+            {
+                for (int j = 0; j < iterations; j++)
+                {
+                    account.UpdateBalance(1);
+                    account.UpdateBalance(-1);
+                }
+            }));
+        }
+        Task.WaitAll(tasks.ToArray());
+
+        Assert.That(account.GetBalance(), Is.EqualTo(0));
     }
 }

--- a/exercises/bank-account/Example.cs
+++ b/exercises/bank-account/Example.cs
@@ -2,36 +2,50 @@
 
 public class BankAccount
 {
+    private readonly object _lock = new object();
+
     private float balance;
     private bool isOpen;
 
     public void Open()
     {
-        isOpen = true;
+        lock(_lock)
+        {
+            isOpen = true;
+        }
     }
 
     public void Close()
     {
-        isOpen = false;
+        lock(_lock)
+        {
+            isOpen = false;
+        }
     }
 
     public float GetBalance()
     {
-        if (!isOpen)
+        lock(_lock)
         {
-            throw new InvalidOperationException("Cannot get balance on an account that isn't open");
-        }
+            if (!isOpen)
+            {
+                throw new InvalidOperationException("Cannot get balance on an account that isn't open");
+            }
 
-        return balance;
+            return balance;
+        }
     }
 
     public void UpdateBalance(float change)
     {
-        if (!isOpen)
+        lock(_lock)
         {
-            throw new InvalidOperationException("Cannot update balance on an account that isn't open");
-        }
+            if (!isOpen)
+            {
+                throw new InvalidOperationException("Cannot update balance on an account that isn't open");
+            }
 
-        balance += change;
+            balance += change;
+        }
     }
 }


### PR DESCRIPTION
Exercise mentions that solution should be thread safe [1]. However, there are no tests to verify that potential solution is thread safe.

Changes:
* Adjusted example implementation to be thread safe
* Added test with threads that is failing with previous implementation


[1] https://github.com/exercism/x-common/blob/master/exercises/bank-account/description.md
> Create an account that can be accessed from multiple threads/processes