### PR TITLE
difference-of-squares: Change expected exception type

### DIFF
--- a/exercises/difference-of-squares/DifferenceOfSquaresTest.cs
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTest.cs
@@ -77,6 +77,6 @@ public class DifferenceOfSquaresTests
     [Test]
     public void Test_negative_numbers_throw_argument_exception()
     {
-        Assert.That(() => new Squares(-5), Throws.TypeOf<ArgumentException>());
+        Assert.That(() => new Squares(-5), Throws.TypeOf<ArgumentOutOfRangeException>());
     }
 }

--- a/exercises/difference-of-squares/DifferenceOfSquaresTest.cs
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTest.cs
@@ -75,7 +75,7 @@ public class DifferenceOfSquaresTests
 
     [Ignore("Remove to run test")]
     [Test]
-    public void Test_negative_numbers_throw_argument_exception()
+    public void Test_negative_numbers_throw_argument_out_of_range_exception()
     {
         Assert.That(() => new Squares(-5), Throws.TypeOf<ArgumentOutOfRangeException>());
     }

--- a/exercises/difference-of-squares/Example.cs
+++ b/exercises/difference-of-squares/Example.cs
@@ -9,7 +9,7 @@ public class Squares
     {
         if (max < 0)
         {
-            throw new ArgumentException("Max must be positive", "max");
+            throw new ArgumentOutOfRangeException("Max must be positive", "max");
         }
 
         this.max = max;


### PR DESCRIPTION
I think it would be better to use the more specific `ArgumentOutOfRangeException` instead of `ArgumentException` here.