### PR TITLE
Add error-handling exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -176,6 +176,13 @@
       ]
     },
     {
+      "slug": "error-handling",
+      "difficulty": 3,
+      "topics": [
+        "Exception handling"
+      ]
+    },
+    {
       "slug": "kindergarten-garden",
       "difficulty": 3,
       "topics": [

--- a/exercises/error-handling/ErrorHandlingTest.cs
+++ b/exercises/error-handling/ErrorHandlingTest.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using NUnit.Framework;
+
+[TestFixture]
+public class ErrorHandlingTest
+{
+    // Read more about exception handling here:
+    // https://msdn.microsoft.com/en-us/library/ms173162.aspx?f=255&MSPPError=-2147217396
+    [TestCase]
+    public void ThrowException()
+    {
+        Assert.Throws<Exception>(ErrorHandling.HandleErrorByThrowingException);
+    }
+
+    // Read more about nullable types here:
+    // https://msdn.microsoft.com/en-us/library/1t3y8s4s.aspx?f=255&MSPPError=-2147217396
+    [TestCase]
+    [Ignore("Remove to run test")]
+    public void ReturnNullableType()
+    {
+        var successfulResult = ErrorHandling.HandleErrorByReturningNullableType("1");
+        Assert.That(successfulResult, Is.EqualTo(1));
+
+        var failureResult = ErrorHandling.HandleErrorByReturningNullableType("a");
+        Assert.That(failureResult, Is.EqualTo(null));
+    }
+
+    // Read more about out parameters here:
+    // https://msdn.microsoft.com/en-us/library/t3c3bfhx.aspx?f=255&MSPPError=-2147217396
+    [TestCase]
+    [Ignore("Remove to run test")]
+    public void ReturnWithOutParameter()
+    {
+        int result;
+        var successfulResult = ErrorHandling.HandleErrorWithOutParam("1", out result);
+        Assert.That(successfulResult, Is.EqualTo(true));
+        Assert.That(result, Is.EqualTo(1));
+        
+        var failureResult = ErrorHandling.HandleErrorWithOutParam("a", out result);
+        Assert.That(failureResult, Is.EqualTo(false));
+        // The value of result is meaningless here (it could be anything) so it shouldn't be used and it's not validated 
+    }
+
+    private class DisposableResource : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            IsDisposed = true;
+        }
+    }
+
+    // Read more about IDisposable here:
+    // https://msdn.microsoft.com/en-us/library/system.idisposable(v=vs.110).aspx
+    [TestCase]
+    [Ignore("Remove to run test")]
+    public void DisposableObjectsAreDisposedWhenThrowingAnException()
+    {
+        var disposbaleResource = new DisposableResource();
+
+        Assert.Throws<Exception>(() => ErrorHandling.DisposableResourcesAreDisposedWhenExceptionIsThrown(disposbaleResource));
+        Assert.That(disposbaleResource.IsDisposed, Is.EqualTo(true));
+    }
+}

--- a/exercises/error-handling/Example.cs
+++ b/exercises/error-handling/Example.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+public static class ErrorHandling
+{
+    public static void HandleErrorByThrowingException()
+    {
+        throw new Exception("An error occured.");
+    }
+
+    public static int? HandleErrorByReturningNullableType(string input)
+    {
+        int result;
+
+        if (int.TryParse(input, out result))
+        {
+            return result;
+        }
+
+        return null;
+    }
+
+    public static bool HandleErrorWithOutParam(string input, out int result)
+    {
+        return int.TryParse(input, out result);
+    }
+
+    public static void DisposableResourcesAreDisposedWhenExceptionIsThrown(IDisposable disposableObject)
+    {
+        using (disposableObject)
+        {
+            throw new Exception("An error occured.");
+        }
+    }
+}


### PR DESCRIPTION
Shameless copy/inspiration from the [F# version](https://github.com/exercism/xfsharp/tree/master/exercises/error-handling).

This leaves on three exercises to be implemented in the [C# track](https://github.com/exercism/xcsharp/issues/171).