### PR TITLE
Added Ignore to Negative_digit test in AllYourBaseTest

### DIFF
--- a/exercises/all-your-base/AllYourBaseTest.cs
+++ b/exercises/all-your-base/AllYourBaseTest.cs
@@ -131,6 +131,7 @@ public class AllYourBaseTest
         Assert.Throws<ArgumentException>(() => Base.Rebase(inputBase, inputDigits, outputBase));
     }
 
+    [Ignore("Remove to run test")]
     [Test]
     public void Negative_digit()
     {


### PR DESCRIPTION
One test (in addition to the first test) in AllYourBaseTest didn't have an Ignore annotation 