### PR TITLE
Changed inputDigits in First_base_is_one test in AllYourBaseTest

### DIFF
--- a/exercises/all-your-base/AllYourBaseTest.cs
+++ b/exercises/all-your-base/AllYourBaseTest.cs
@@ -156,7 +156,7 @@ public class AllYourBaseTest
     public void First_base_is_one()
     {
         const int inputBase = 1;
-        var inputDigits = new int[0];
+        var inputDigits = new[] { 1, 0, 1, 0, 1, 0 };
         const int outputBase = 10;
         Assert.Throws<ArgumentException>(() => Base.Rebase(inputBase, inputDigits, outputBase));
     }


### PR DESCRIPTION
Changed inputDigits in First_base_is_one test to be an array with values, not an empty array. Since the test for throwing an exception when inputDigits is empty is before this one, this test is redundant when inputDigits is empty. Assuming the intention is to test that an exception is thrown when the first base is one, this should fix that so that the correct thing is tested.