### PR TITLE
poker: straight to 5 in ascending order in example

### DIFF
--- a/exercises/poker/Example.cs
+++ b/exercises/poker/Example.cs
@@ -52,7 +52,7 @@ public static class Poker
 
         if (ranks.SequenceEqual(new[] { 14, 5, 4, 3, 2 }))
         {
-            ranks = new[] { 1, 2, 3, 4, 5 };
+            ranks = new[] { 5, 4, 3, 2, 1 };
         }
         
         var flush = suits.Distinct().Count() == 1;

--- a/exercises/poker/PokerTest.cs
+++ b/exercises/poker/PokerTest.cs
@@ -169,13 +169,13 @@ public class PokerTest
             Is.EqualTo(new[] { spadeStraightTo9, diamondStraightTo9 }));
     }
 
-    [Ignore("Remove torun test")]
+    [Ignore("Remove to run test")]
     [Test]
     public void Straight_to_5_against_a_pair_of_jacks()
     {
         const string straightTo5 = "2S 4D 5C 3S AS";
         const string twoJacks = "JD 8D 7D JC 5D";
-        Assert.That(Pokder.BestHands(new{} { straightTo5, twoJacks }),
+        Assert.That(Poker.BestHands(new[] { straightTo5, twoJacks }),
             Is.EqualTo(new[] { straightTo5 }));
     }
 }

--- a/exercises/poker/PokerTest.cs
+++ b/exercises/poker/PokerTest.cs
@@ -168,4 +168,14 @@ public class PokerTest
         Assert.That(Poker.BestHands(new[] { spadeStraightTo9, diamondStraightTo9, threeOf4 }),
             Is.EqualTo(new[] { spadeStraightTo9, diamondStraightTo9 }));
     }
+
+    [Ignore("Remove torun test")]
+    [Test]
+    public void Straight_to_5_against_a_pair_of_jacks()
+    {
+        const string straightTo5 = "2S 4D 5C 3S AS";
+        const string twoJacks = "JD 8D 7D JC 5D";
+        Assert.That(Pokder.BestHands(new{} { straightTo5, twoJacks }),
+            Is.EqualTo(new[] { straightTo5 }));
+    }
 }


### PR DESCRIPTION
While working with this exercise in Delphi it seemed to me that straight to 5 should be in descending order in the example.  I learned that all the tests would pass regardless if straight to 5 was ascending or descending.  I added a test that showed that ascending didn't work, descending does.  Hopefully I have found something here.