### PR TITLE
[WIP]: Use Cake instead of Fake.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,91 @@
+#addin "Cake.FileHelpers"
+
+// TODO:
+// Remove comments
+// Add option to take in project name from command line
+// Beautify
+// Remove limit of 2 from everywhere
+
+var target = Argument("target", "Default");
+var project = Argument("project", "*");
+
+var buildDir = "./build/";
+var sourceDir = "./exercises/";
+var projects = GetFiles(buildDir + "**/" + project + ".csproj");
+
+
+Task("Clean")
+	.Does(() => {
+		CleanDirectory("./build/");   
+    });
+
+
+// Copy everything to build so we make no changes in the 
+// actual files.
+Task("Copy-Exercises")
+    .IsDependentOn("Clean")
+    .Does(() => {
+        CopyDirectory(sourceDir, buildDir);
+    });
+
+
+Task("Restore-Nuget-Packages")
+    .IsDependentOn("Copy-Exercises")
+    .Does(() => {
+       foreach (var project in projects) {
+            DotNetCoreRestore(project.ToString());
+       }
+    });
+
+
+Task("Enable-All-Tests")
+    .IsDependentOn("Restore-Nuget-Packages")
+    .Does(() => {
+        var testFiles = GetFiles(buildDir + "**/*Test.cs");
+        foreach (var testFile in testFiles) {
+            var skipRE = @"Skip\s*=\s*""Remove to run test""";
+            ReplaceRegexInFiles(buildDir + "**/*Test.cs", skipRE, "");
+        }
+
+    });
+
+
+Task("Replace-Stub-With-Example")
+    .IsDependentOn("Enable-All-Tests")
+    .Does(() => {
+        foreach (var project in projects) {
+            var projectDir = project.GetDirectory();
+            var projectName = project.GetFilenameWithoutExtension();
+            var stub = projectDir.GetFilePath(projectName).AppendExtension("cs");
+            var example = projectDir.GetFilePath("Example.cs");
+            
+            DeleteFile(stub);
+            MoveFile(example, stub);
+        }
+    });
+
+
+Task("Build")
+    .IsDependentOn("Replace-Stub-With-Example")
+    .Does(() => {
+       foreach (var project in projects) {
+            DotNetCoreBuild(project.ToString());
+       }
+    });
+
+
+Task("Test")
+    .IsDependentOn("Build")
+    .Does(() => {
+        foreach (var project in projects) {
+            DotNetCoreTest(project.ToString());
+        }
+    });
+
+
+Task("Default")
+    .IsDependentOn("Test")
+    .Does(() => {});
+
+
+RunTarget(target);

--- a/build.cake
+++ b/build.cake
@@ -1,11 +1,9 @@
 #addin "Cake.FileHelpers"
 
 var target = Argument("target", "Default");
-var project = Argument("project", "*");
 
 var buildDir = "./build/";
 var sourceDir = "./exercises/";
-var projectDirs = GetFiles(buildDir + "**/" + project + ".csproj");
 
 var allProjects = GetFiles(buildDir + "**/*.csproj");
 
@@ -28,7 +26,7 @@ var refactoringProjects = GetFiles(buildDir + "**/TreeBuilding.csproj")
 
 
 Task("Clean")
-	.Does(() => {
+    .Does(() => {
 		CleanDirectory(buildDir);   
     });
 
@@ -44,8 +42,8 @@ Task("CopyExercises")
 Task("RestoreNugetPackages")
     .IsDependentOn("CopyExercises")
     .Does(() => {
-       foreach (var project in projectDirs) {
-           DotNetCoreRestore(project.ToString());
+       foreach (var project in allProjects) {
+           DotNetCoreRestore(project.FullPath);
        }
     });
 
@@ -54,25 +52,24 @@ Task("RestoreAndBuildStubImplementations")
     .IsDependentOn("RestoreNugetPackages")
     .Does(() => {
         foreach (var project in defaultProjects) {
-            DotNetCoreBuild(project.ToString());
+            DotNetCoreBuild(project.FullPath);
         }
 });
+
 
 Task("EnableAllTests")
     .IsDependentOn("RestoreAndBuildStubImplementations")
     .Does(() => {
-        var testFiles = GetFiles(buildDir + "**/*Test.cs");
-        foreach (var testFile in testFiles) {
-            var skipRE = @"Skip\s*=\s*""Remove to run test""";
-            ReplaceRegexInFiles(buildDir + "**/*Test.cs", skipRE, "");
-        }
+        var skipRE = @"Skip\s*=\s*""Remove to run test""";
+        ReplaceRegexInFiles(buildDir + "**/*Test.cs", skipRE, "");
     });
+
 
 Task("RestoreAndTestRefactoringProjects")
     .IsDependentOn("EnableAllTests")
     .Does(() => {
         foreach (var project in refactoringProjects) {
-            DotNetCoreTest(project.ToString());
+            DotNetCoreTest(project.FullPath);
         }
 });
 
@@ -91,18 +88,19 @@ Task("ReplaceStubWithExample")
         }
     });
 
+
 Task("TestUsingExampleImplementation")
     .IsDependentOn("ReplaceStubWithExample")
     .Does(() => {
         foreach (var project in allProjects) {
-            DotNetCoreTest(project.ToString());
+            DotNetCoreTest(project.FullPath);
         }
     });
-
+    
 
 Task("Default")
     .IsDependentOn("TestUsingExampleImplementation")
-    .Does(() => {});
+    .Does(() => { });
 
 
 RunTarget(target);

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,189 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+<#
+
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+
+.PARAMETER Script
+The build script to execute.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER Experimental
+Tells Cake to use the latest Roslyn release.
+.PARAMETER WhatIf
+Performs a dry run of the build script.
+No tasks will be executed.
+.PARAMETER Mono
+Tells Cake to use the Mono scripting engine.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+
+.LINK
+http://cakebuild.net
+
+#>
+
+[CmdletBinding()]
+Param(
+    [string]$Script = "build.cake",
+    [string]$Target = "Default",
+    [ValidateSet("Release", "Debug")]
+    [string]$Configuration = "Release",
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity = "Verbose",
+    [switch]$Experimental,
+    [Alias("DryRun","Noop")]
+    [switch]$WhatIf,
+    [switch]$Mono,
+    [switch]$SkipToolPackageRestore,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs
+)
+
+[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
+function MD5HashFile([string] $filePath)
+{
+    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
+    {
+        return $null
+    }
+
+    [System.IO.Stream] $file = $null;
+    [System.Security.Cryptography.MD5] $md5 = $null;
+    try
+    {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $file = [System.IO.File]::OpenRead($filePath)
+        return [System.BitConverter]::ToString($md5.ComputeHash($file))
+    }
+    finally
+    {
+        if ($file -ne $null)
+        {
+            $file.Dispose()
+        }
+    }
+}
+
+Write-Host "Preparing to run build script..."
+
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
+
+# Should we use mono?
+$UseMono = "";
+if($Mono.IsPresent) {
+    Write-Verbose -Message "Using the Mono based scripting engine."
+    $UseMono = "-mono"
+}
+
+# Should we use the new Roslyn?
+$UseExperimental = "";
+if($Experimental.IsPresent -and !($Mono.IsPresent)) {
+    Write-Verbose -Message "Using experimental version of Roslyn."
+    $UseExperimental = "-experimental"
+}
+
+# Is this a dry run?
+$UseDryRun = "";
+if($WhatIf.IsPresent) {
+    $UseDryRun = "-dryrun"
+}
+
+# Make sure tools folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type directory | out-null
+}
+
+# Make sure that packages.config exist.
+if (!(Test-Path $PACKAGES_CONFIG)) {
+    Write-Verbose -Message "Downloading packages.config..."
+    try { (New-Object System.Net.WebClient).DownloadFile("http://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
+        Throw "Could not download packages.config."
+    }
+}
+
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
+    }
+}
+
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        (New-Object System.Net.WebClient).DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
+}
+
+# Save nuget.exe path to environment to be available to child processed
+$ENV:NUGET_EXE = $NUGET_EXE
+
+# Restore tools from NuGet?
+if(-Not $SkipToolPackageRestore.IsPresent) {
+    Push-Location
+    Set-Location $TOOLS_DIR
+
+    # Check for changes in packages.config and remove installed tools if true.
+    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
+      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        Write-Verbose -Message "Missing or changed package.config hash..."
+        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+    }
+
+    Write-Verbose -Message "Restoring tools from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occured while restoring NuGet tools."
+    }
+    else
+    {
+        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
+    }
+    Write-Verbose -Message ($NuGetOutput | out-string)
+    Pop-Location
+}
+
+# Make sure that Cake has been installed.
+if (!(Test-Path $CAKE_EXE)) {
+    Throw "Could not find Cake.exe at $CAKE_EXE"
+}
+
+# Start Cake
+Write-Host "Running build script..."
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -1,33 +1,101 @@
-#!/bin/bash
-if test "$OS" = "Windows_NT"
-then
-  # use .Net
+#!/usr/bin/env bash
 
-  .paket/paket.bootstrapper.exe
-  exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-  	exit $exit_code
-  fi
+##########################################################################
+# This is the Cake bootstrapper script for Linux and OS X.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
 
-  .paket/paket.exe restore
-  exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-  	exit $exit_code
-  fi
+# Define directories.
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+TOOLS_DIR=$SCRIPT_DIR/tools
+NUGET_EXE=$TOOLS_DIR/nuget.exe
+CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
+PACKAGES_CONFIG=$TOOLS_DIR/packages.config
+PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
 
-  packages/FAKE/tools/FAKE.exe $@ --fsiargs build.fsx
+# Define md5sum or md5 depending on Linux/OSX
+MD5_EXE=
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    MD5_EXE="md5 -r"
 else
-  # use mono
-  mono .paket/paket.bootstrapper.exe
-  exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-  	exit $exit_code
-  fi
+    MD5_EXE="md5sum"
+fi
 
-  mono .paket/paket.exe restore
-  exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-  	exit $exit_code
-  fi
-  mono packages/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
+# Define default arguments.
+SCRIPT="build.cake"
+TARGET="Default"
+CONFIGURATION="Release"
+VERBOSITY="verbose"
+DRYRUN=
+SHOW_VERSION=false
+SCRIPT_ARGUMENTS=()
+
+# Parse arguments.
+for i in "$@"; do
+    case $1 in
+        -s|--script) SCRIPT="$2"; shift ;;
+        -t|--target) TARGET="$2"; shift ;;
+        -c|--configuration) CONFIGURATION="$2"; shift ;;
+        -v|--verbosity) VERBOSITY="$2"; shift ;;
+        -d|--dryrun) DRYRUN="-dryrun" ;;
+        --version) SHOW_VERSION=true ;;
+        --) shift; SCRIPT_ARGUMENTS+=("$@"); break ;;
+        *) SCRIPT_ARGUMENTS+=("$1") ;;
+    esac
+    shift
+done
+
+# Make sure the tools folder exist.
+if [ ! -d "$TOOLS_DIR" ]; then
+  mkdir "$TOOLS_DIR"
+fi
+
+# Make sure that packages.config exist.
+if [ ! -f "$TOOLS_DIR/packages.config" ]; then
+    echo "Downloading packages.config..."
+    curl -Lsfo "$TOOLS_DIR/packages.config" http://cakebuild.net/download/bootstrapper/packages
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading packages.config."
+        exit 1
+    fi
+fi
+
+# Download NuGet if it does not exist.
+if [ ! -f "$NUGET_EXE" ]; then
+    echo "Downloading NuGet..."
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading nuget.exe."
+        exit 1
+    fi
+fi
+
+# Restore tools from NuGet.
+pushd "$TOOLS_DIR" >/dev/null
+if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/\r$//' )" != "$( $MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' )" ]; then
+    find . -type d ! -name . | xargs rm -rf
+fi
+
+mono "$NUGET_EXE" install -ExcludeVersion
+if [ $? -ne 0 ]; then
+    echo "Could not restore NuGet packages."
+    exit 1
+fi
+
+$MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' >| "$PACKAGES_CONFIG_MD5"
+
+popd >/dev/null
+
+# Make sure that Cake has been installed.
+if [ ! -f "$CAKE_EXE" ]; then
+    echo "Could not find Cake.exe at '$CAKE_EXE'."
+    exit 1
+fi
+
+# Start Cake
+if $SHOW_VERSION; then
+    exec mono "$CAKE_EXE" -version
+else
+    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
 fi

--- a/exercises/exercises.sln
+++ b/exercises/exercises.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
-MinimumVisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 15.0.26124.0
 Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "accumulate", "accumulate\accumulate.csproj", "{D063D598-EF0B-4EC7-9524-1CF222700A29}"
 EndProject
 Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "acronym", "acronym\acronym.csproj", "{F3F868D6-685C-45C2-B02E-8B9A2F9E7A83}"

--- a/exercises/exercises.sln
+++ b/exercises/exercises.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
-MinimumVisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 14.0.25420.1
 Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "accumulate", "accumulate\accumulate.csproj", "{D063D598-EF0B-4EC7-9524-1CF222700A29}"
 EndProject
 Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "acronym", "acronym\acronym.csproj", "{F3F868D6-685C-45C2-B02E-8B9A2F9E7A83}"


### PR DESCRIPTION
There are a few things missing since this is a WIP. But gets the build working.

- [ ] Refactor the repeated `GetFiles(buildDir + "**/*.csproj")` pattern.
- [x] Change `project.ToString()` to `FilePath.FullPath`
- [ ] This currently runs all the projects. Allow project-name to be passed as command line param.
- [ ] Test on *nix.

- [ ] Remove paket related files.

Strangely, this is failing on AtbashTest.cs -- weirdly picking up the stub file even though that is replaced with the Example file. All the projects before it pass without any issues.