### PR TITLE
Leap test generator

### DIFF
--- a/exercises/leap/LeapTest.cs
+++ b/exercises/leap/LeapTest.cs
@@ -3,26 +3,26 @@ using Xunit;
 public class LeapTest
 {
     [Fact]
-    public void Valid_leap_year()
+    public void Year_not_divisible_by_4_is_common_year()
     {
-        Assert.True(Year.IsLeap(1996));
+        Assert.False(Year.IsLeap(2015));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Invalid_leap_year()
+    public void Year_divisible_by_4_not_divisible_by_100_is_leap_year()
     {
-        Assert.False(Year.IsLeap(1997));
+        Assert.True(Year.IsLeap(2016));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Turn_of_the_20th_century_is_not_a_leap_year()
+    public void Year_divisible_by_100_not_divisible_by_400_is_common_year()
     {
-        Assert.False(Year.IsLeap(1900));
+        Assert.False(Year.IsLeap(2100));
     }
 
     [Fact(Skip = "Remove to run test")]
-    public void Turn_of_the_25th_century_is_a_leap_year()
+    public void Year_divisible_by_400_is_leap_year()
     {
-        Assert.True(Year.IsLeap(2400));
+        Assert.True(Year.IsLeap(2000));
     }
 }

--- a/generators/Exercises/LeapExercise.cs
+++ b/generators/Exercises/LeapExercise.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using Humanizer;
+
+namespace Generators.Exercises
+{
+    public class LeapExercise : Exercise
+    {
+        public LeapExercise() : base("leap")
+        {
+        }
+
+        public override TestClass CreateTestClass(CanonicalData canonicalData)
+        {
+            return new TestClass
+            {
+                ClassName = "Leap",
+                TestMethods = canonicalData.Cases.Select(CreateTestMethod).ToArray()
+            };
+        }
+
+        private static TestMethod CreateTestMethod(CanonicalDataCase canonicalDataCase, int index)
+        {
+            var year = Convert.ToInt32(canonicalDataCase.Input);
+            var isTrue = Convert.ToBoolean(canonicalDataCase.Expected);
+
+            return new TestMethod
+            {
+                Index = index,
+                MethodName = canonicalDataCase.Description.Replace(":", " is").Transform(To.TestMethodName),
+                Body = $"Assert.{isTrue}(Year.IsLeap({year}));"
+            };
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a test generator for the `leap` exercise. It show how such a test generator can loop like, with the caveat that `leap` is of course quite a simple exercise. This PR is on hold until #228 has been merged, as it depends on the functionality in that PR.