### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -468,7 +468,7 @@
         "Parsing",
         "Transforming"
       ]
-    },   
+    },
     {
       "slug": "atbash-cipher",
       "difficulty": 5,
@@ -560,7 +560,7 @@
         "Text formatting",
         "Refactoring"
       ]
-    }, 
+    },
     {
       "slug": "custom-set",
       "difficulty": 5,
@@ -722,7 +722,7 @@
       "difficulty": 7,
       "topics": [
         "Tuples",
-        "Arrays"        
+        "Arrays"
       ]
     },
     {
@@ -864,12 +864,7 @@
     "octal",
     "hexadecimal"
   ],
-  "ignored": [
-    "docs",
-    "img",
-    "generators"
-  ],
-  "foregone": [    
+  "foregone": [
     "lens-person",
     "nucleotide-codons",
     "paasio",


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.